### PR TITLE
fix: taito-workshop.local urls changed to taito-devops-workshop.local…

### DIFF
--- a/devops/exercises/04.md
+++ b/devops/exercises/04.md
@@ -149,10 +149,10 @@ minikube ip
 Copy the IP address and add the following line to your `/etc/hosts` file:
 
 ```sh
-<minikube-ip> taito-workshop.local
+<minikube-ip> taito-devops-workshop.local
 ```
 
-Now go to [taito-workshop.local](http://taito-workshop.local) in your browser to see the application running.
+Now go to [taito-devops-workshop.local](http://taito-devops-workshop.local) in your browser to see the application running.
 
 Vola 🎉! You have successfully deployed the application to the Minikube cluster using Terraform and Helm 👏🏻
 
@@ -192,7 +192,7 @@ terraform apply -auto-approve
 
 This will update the Helm release with the new image tag and deploy the updated application to the Kubernetes cluster.
 
-Go to [taito-workshop.local](http://taito-workshop.local) in your browser to see the updated application running.
+Go to [taito-devops-workshop.local](http://taito-devops-workshop.local) in your browser to see the updated application running.
 
 ## 7. Clean up
 


### PR DESCRIPTION
I was doing this exercise and it didn't work with `taito-workshop.local` as the url, even if I set it in hosts-file as described. It would connect to nginx but display 404. The host is defined for the ingress as `taito-devops-workshop.local` and using that made it work. So I changed it. This was in exercise 04.md only.